### PR TITLE
비관적 락을 통한 동시성 제어

### DIFF
--- a/src/main/java/concert/application/ReservationFacade.java
+++ b/src/main/java/concert/application/ReservationFacade.java
@@ -39,6 +39,10 @@ public class ReservationFacade {
         try {
             Seat seat = concertService.getSeatByOptimisticLock(seatId);
 
+            /**
+             * 생각 해보니까 낙관적 락 만을 사용하는게 아니라 이 if문을 통해 제어를 같이 한다는 생각이 들었습니다.
+             * 이 if문 없이 낙관적락 버전이 바뀌면 아래 catch문으로 가고싶은데 왜 안걸리는지 잘 모르겠습니다..
+             */
             if (seat.getSeatStatus() != SeatStatus.AVAILABLE) {
                 throw new BusinessException("이미 예약된 좌석입니다.");
             }

--- a/src/main/java/concert/domain/concert/ConcertRepository.java
+++ b/src/main/java/concert/domain/concert/ConcertRepository.java
@@ -22,6 +22,7 @@ public interface ConcertRepository {
     Seat save(Seat seat);
     Optional<Seat> findBySeatId(Long seatId);
     Optional<Seat> findByIdOptimisticLock(Long seatId);
+    Optional<Seat> findByIdPessimisticLock(Long seatId);
 
     void deleteAllInBatch();
     List<Seat> saveAll(List<Seat> seats);

--- a/src/main/java/concert/domain/concert/ConcertRepository.java
+++ b/src/main/java/concert/domain/concert/ConcertRepository.java
@@ -21,6 +21,7 @@ public interface ConcertRepository {
     List<Seat> findByConcertScheduleIdAndSeatStatus(Long concertScheduleId,SeatStatus seatStatus);
     Seat save(Seat seat);
     Optional<Seat> findBySeatId(Long seatId);
+    Optional<Seat> findByIdOptimisticLock(Long seatId);
 
     void deleteAllInBatch();
     List<Seat> saveAll(List<Seat> seats);

--- a/src/main/java/concert/domain/concert/ConcertService.java
+++ b/src/main/java/concert/domain/concert/ConcertService.java
@@ -2,6 +2,7 @@ package concert.domain.concert;
 
 import concert.application.dto.CreateConcertDto;
 import concert.common.exception.BusinessException;
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,7 @@ public class ConcertService {
 
 
     public List<ConcertSchedule> availableDates(Long concertId) {
-        log.info("ConcertService availableDates(): concertId={}",concertId);
+        log.info("ConcertService availableDates(): concertId={}", concertId);
 
         Concert concert = getConcert(concertId);
 
@@ -37,18 +38,18 @@ public class ConcertService {
     }
 
     public List<Seat> availableSeats(Long concertId, LocalDateTime concertDate) {
-        log.info("ConcertService availableSeats(): concertId={}, concertDate={}",concertId,concertDate);
+        log.info("ConcertService availableSeats(): concertId={}, concertDate={}", concertId, concertDate);
         Concert concert = getConcert(concertId);
 
         ConcertSchedule concertSchedule = concertRepository.findByConcertIdAndConcertDateTime(concert.getId(), concertDate)
-                .orElseThrow(()->new BusinessException("해당 날짜에 해당하는 콘서트가 없습니다."));
+                .orElseThrow(() -> new BusinessException("해당 날짜에 해당하는 콘서트가 없습니다."));
 
         return concertRepository.findByConcertScheduleIdAndSeatStatus(concertSchedule.getConcertId(), SeatStatus.AVAILABLE);
     }
 
     public Concert getConcert(Long concertId) {
-        log.info("ConcertService getConcert(): concertId={}",concertId);
-      
+        log.info("ConcertService getConcert(): concertId={}", concertId);
+
         return concertRepository.findById(concertId)
                 .orElseThrow(() -> new BusinessException("해당 콘서트가 없습니다."));
     }
@@ -60,22 +61,29 @@ public class ConcertService {
                 .orElseThrow(() -> new BusinessException("좌석이 존재하지 않습니다."));
     }
 
-    public ConcertSchedule getConcertSchedule(Long concertScheduleId){
+    public Seat getSeatByOptimisticLock(Long seatId) {
+        log.info("ConcertService getSeatByOptimisticLock(): seatId={}", seatId);
+
+        return concertRepository.findByIdOptimisticLock(seatId)
+                .orElseThrow(() -> new BusinessException("좌석이 존재하지 않습니다."));
+    }
+
+    public ConcertSchedule getConcertSchedule(Long concertScheduleId) {
         return concertRepository.findScheduleById(concertScheduleId)
                 .orElseThrow(() -> new BusinessException("콘서트 스케줄이 존재하지 않습니다."));
     }
 
     @Transactional
-    public CreateConcertDto createConcert(String name, String title, LocalDateTime concertDateTime , int baseSeatPrice) {
+    public CreateConcertDto createConcert(String name, String title, LocalDateTime concertDateTime, int baseSeatPrice) {
         Concert concert = concertRepository.save(Concert.create(title, name));
-        ConcertSchedule concertSchedule = concertRepository.save(ConcertSchedule.create(concert.getId(),concertDateTime));
+        ConcertSchedule concertSchedule = concertRepository.save(ConcertSchedule.create(concert.getId(), concertDateTime));
 
 
         List<Seat> seats = createSeats(concertSchedule.getId(), baseSeatPrice);
 
         List<Seat> savedSeats = concertRepository.saveAll(seats);
 
-        return new CreateConcertDto(concert.getId(), concert.getTitle(), concert.getName(), concertSchedule.getId(), concertSchedule.getConcertDateTime(),savedSeats);
+        return new CreateConcertDto(concert.getId(), concert.getTitle(), concert.getName(), concertSchedule.getId(), concertSchedule.getConcertDateTime(), savedSeats);
     }
 
     public List<Seat> createSeats(Long concertScheduleId, int baseSeatPrice) {

--- a/src/main/java/concert/domain/concert/ConcertService.java
+++ b/src/main/java/concert/domain/concert/ConcertService.java
@@ -68,6 +68,13 @@ public class ConcertService {
                 .orElseThrow(() -> new BusinessException("좌석이 존재하지 않습니다."));
     }
 
+    public Seat getSeatByPessimisticLock(Long seatId) {
+        log.info("ConcertService getSeatByPessimisticLock(): seatId={}", seatId);
+
+        return concertRepository.findByIdPessimisticLock(seatId)
+                .orElseThrow(() -> new BusinessException("좌석이 존재하지 않습니다."));
+    }
+
     public ConcertSchedule getConcertSchedule(Long concertScheduleId) {
         return concertRepository.findScheduleById(concertScheduleId)
                 .orElseThrow(() -> new BusinessException("콘서트 스케줄이 존재하지 않습니다."));

--- a/src/main/java/concert/domain/concert/Seat.java
+++ b/src/main/java/concert/domain/concert/Seat.java
@@ -29,10 +29,10 @@ public class Seat {
     private SeatStatus seatStatus;
     private int seatPrice;
 
-    @Version
-    private Long version;
-
     public void seatStatusReserved(){
+        if (this.seatStatus != SeatStatus.AVAILABLE) {
+            throw new BusinessException("이미 예약된 좌석입니다.");
+        }
         this.seatStatus = SeatStatus.RESERVED;
     }
     public void seatStatusAvailable(){

--- a/src/main/java/concert/domain/concert/Seat.java
+++ b/src/main/java/concert/domain/concert/Seat.java
@@ -1,5 +1,6 @@
 package concert.domain.concert;
 
+import concert.common.exception.BusinessException;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,12 +29,16 @@ public class Seat {
     private SeatStatus seatStatus;
     private int seatPrice;
 
+    @Version
+    private Long version;
+
     public void seatStatusReserved(){
         this.seatStatus = SeatStatus.RESERVED;
     }
     public void seatStatusAvailable(){
         this.seatStatus = SeatStatus.AVAILABLE;
     }
+
     public static Seat create(Long concertScheduleId,int seatNumber,int seatPrice){
         return Seat.builder()
                 .concertScheduleId(concertScheduleId)

--- a/src/main/java/concert/domain/reservation/Reservation.java
+++ b/src/main/java/concert/domain/reservation/Reservation.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 
+
 @Slf4j
 @Getter
 @Entity

--- a/src/main/java/concert/domain/reservation/Reservation.java
+++ b/src/main/java/concert/domain/reservation/Reservation.java
@@ -15,10 +15,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(uniqueConstraints = {
+
         @UniqueConstraint(columnNames = {"concertDate", "seatId"})
 })
 public class Reservation {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/concert/domain/reservation/Reservation.java
+++ b/src/main/java/concert/domain/reservation/Reservation.java
@@ -14,10 +14,6 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(uniqueConstraints = {
-
-        @UniqueConstraint(columnNames = {"concertDate", "seatId"})
-})
 public class Reservation {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/concert/domain/reservation/ReservationService.java
+++ b/src/main/java/concert/domain/reservation/ReservationService.java
@@ -35,28 +35,24 @@ public class ReservationService {
     }
 
     @Transactional
-    public Reservation reserveSeat(LocalDateTime concertDate, Long seatId,Long userId,int seatPrice) {
+    public Reservation reserveSeat(LocalDateTime concertDate, Long seatId, Long userId, int seatPrice) {
         log.info("ReservationService reserveSeat()");
         Reservation existingReservation = reservationRepository.findByConcertDateAndSeatIdAndStatus(concertDate, seatId, ReservationStatus.RESERVED);
         if (existingReservation != null) {
-            log.warn("Duplicated Reservation Seat: concertDate={}, seatId={}",concertDate,seatId);
+            log.warn("Duplicated Reservation Seat: concertDate={}, seatId={}", concertDate, seatId);
             throw new BusinessException("좌석이 이미 예약되었습니다.");
         }
 
-        Reservation reservation = Reservation.createReservation(seatId,concertDate,FIXED_EXPIRED_MINUTES,userId,seatPrice);
+        Reservation reservation = Reservation.createReservation(seatId, concertDate, FIXED_EXPIRED_MINUTES, userId, seatPrice);
 
-        try {
-            return reservationRepository.save(reservation);
-        } catch (DataIntegrityViolationException e) {
-            log.warn("Concurrency Reservation Seat: seatId",reservation.getSeatId());
-            throw new BusinessException("동시에 같은 좌석을 예약하려는 시도가 있었습니다.");
-        }
+        return reservationRepository.save(reservation);
+
     }
 
     @Transactional
     public Payment createPayment(long reservationId, int amount) {
         log.info("ReservationService createPayment()");
-        Payment payment = Payment.createPayment(reservationId,amount);
+        Payment payment = Payment.createPayment(reservationId, amount);
         return reservationRepository.save(payment);
     }
 }

--- a/src/main/java/concert/domain/user/User.java
+++ b/src/main/java/concert/domain/user/User.java
@@ -27,9 +27,6 @@ public class User {
     private String phone;
     private int amount;
 
-    @Version
-    private Long version;
-
     public int chargeAmount(long amount) {
         log.info("chargeAmount(): username={},amount={}",this.username,amount);
         return this.amount += amount;

--- a/src/main/java/concert/domain/user/User.java
+++ b/src/main/java/concert/domain/user/User.java
@@ -27,6 +27,9 @@ public class User {
     private String phone;
     private int amount;
 
+    @Version
+    private Long version;
+
     public int chargeAmount(long amount) {
         log.info("chargeAmount(): username={},amount={}",this.username,amount);
         return this.amount += amount;

--- a/src/main/java/concert/domain/user/UserRepository.java
+++ b/src/main/java/concert/domain/user/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository {
     AmountHistory save(AmountHistory amountHistory);
     void deleteAllInBatch();
     Optional<User> findByIdWithOptimisticLock(Long id);
+    Optional<User> findByIdWithPessimisticLock(Long id);
 }

--- a/src/main/java/concert/domain/user/UserRepository.java
+++ b/src/main/java/concert/domain/user/UserRepository.java
@@ -10,5 +10,5 @@ public interface UserRepository {
 
     AmountHistory save(AmountHistory amountHistory);
     void deleteAllInBatch();
-
+    Optional<User> findByIdWithOptimisticLock(Long id);
 }

--- a/src/main/java/concert/domain/user/UserService.java
+++ b/src/main/java/concert/domain/user/UserService.java
@@ -1,8 +1,10 @@
 package concert.domain.user;
 
 import concert.common.exception.BusinessException;
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,9 +21,14 @@ public class UserService {
                 .orElseThrow(() -> new BusinessException("회원을 찾을수 없습니다."));
     }
 
+    public User getUserWithOptimisticLock(Long userId) {
+        return userRepository.findByIdWithOptimisticLock(userId)
+                .orElseThrow(() -> new BusinessException("회원을 찾을수 없습니다."));
+    }
+
     @Transactional
     public void processPayment(Long userId, int amount) {
-        log.info("UserService processPayment(): userId={}, amount={}",userId,amount);
+        log.info("UserService processPayment(): userId={}, amount={}", userId, amount);
         User user = getUser(userId);
         user.validateAndDecreaseAmount(amount);
         userRepository.save(user);
@@ -35,21 +42,26 @@ public class UserService {
 
     @Transactional
     public AmountChargeDto chargeAmount(Long userId, int amount) {
-        log.info("UserService chargeAmount(): userId={}, amount={}",userId,amount);
-        User user = getUser(userId);
-        int savedAmount = user.chargeAmount(amount);
+        log.info("UserService chargeAmount(): userId={}, amount={}", userId, amount);
+        try {
+            User user = getUserWithOptimisticLock(userId);
 
-        AmountHistory amountHistory = userRepository.save(AmountHistory.builder()
-                .userId(userId)
-                .remainAmount(savedAmount)
-                .useAmount(amount)
-                .status(AmountStatus.CHARGE)
-                .build());
-        return new AmountChargeDto(user, amountHistory);
+            int savedAmount = user.chargeAmount(amount);
+            AmountHistory amountHistory = userRepository.save(AmountHistory.builder()
+                    .userId(userId)
+                    .remainAmount(savedAmount)
+                    .useAmount(amount)
+                    .status(AmountStatus.CHARGE)
+                    .build());
+            return new AmountChargeDto(user, amountHistory);
+        }catch (OptimisticLockingFailureException e) {
+            log.warn("충전 중 낙관적 락 예외 발생. userId: {}, amount: {}", userId, amount);
+            throw new BusinessException("짧은 시간 내에 포인트 충전 요청이 들어와 작업을 차단시켰습니다.");
+        }
     }
 
     private void saveAmountHistory(User user, int amount) {
-        log.info("UserService saveAmountHistory(): userId={}, amount={}",user.getId(),amount);
+        log.info("UserService saveAmountHistory(): userId={}, amount={}", user.getId(), amount);
         AmountHistory amountHistory = AmountHistory.builder()
                 .userId(user.getId())
                 .useAmount(amount)

--- a/src/main/java/concert/infrastructure/concert/ConcertRepositoryImpl.java
+++ b/src/main/java/concert/infrastructure/concert/ConcertRepositoryImpl.java
@@ -67,6 +67,11 @@ public class ConcertRepositoryImpl implements ConcertRepository {
         return seatJpaRepository.findById(seatId);
     }
 
+    @Override
+    public Optional<Seat> findByIdOptimisticLock(Long seatId) {
+        return seatJpaRepository.findByIdOptimisticLock(seatId);
+    }
+
 
     @Override
     public void deleteAllInBatch() {

--- a/src/main/java/concert/infrastructure/concert/ConcertRepositoryImpl.java
+++ b/src/main/java/concert/infrastructure/concert/ConcertRepositoryImpl.java
@@ -72,6 +72,11 @@ public class ConcertRepositoryImpl implements ConcertRepository {
         return seatJpaRepository.findByIdOptimisticLock(seatId);
     }
 
+    @Override
+    public Optional<Seat> findByIdPessimisticLock(Long seatId) {
+        return seatJpaRepository.findByIdPessimisticLock(seatId);
+    }
+
 
     @Override
     public void deleteAllInBatch() {

--- a/src/main/java/concert/infrastructure/concert/SeatJpaRepository.java
+++ b/src/main/java/concert/infrastructure/concert/SeatJpaRepository.java
@@ -19,4 +19,9 @@ public interface SeatJpaRepository extends JpaRepository<Seat,Long> {
     @Lock(value = LockModeType.OPTIMISTIC)
     @Query("select s from Seat s where id = :seatId")
     Optional<Seat> findByIdOptimisticLock(Long seatId);
+
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from Seat s where id = :seatId")
+    Optional<Seat> findByIdPessimisticLock(Long seatId);
+
 }

--- a/src/main/java/concert/infrastructure/concert/SeatJpaRepository.java
+++ b/src/main/java/concert/infrastructure/concert/SeatJpaRepository.java
@@ -2,7 +2,10 @@ package concert.infrastructure.concert;
 
 import concert.domain.concert.Seat;
 import concert.domain.concert.SeatStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +15,8 @@ public interface SeatJpaRepository extends JpaRepository<Seat,Long> {
     List<Seat> findByConcertScheduleIdAndSeatStatus(Long concertScheduleId, SeatStatus seatStatus);
     Seat save(Seat seat);
     Optional<Seat> findById(Long seatId);
+
+    @Lock(value = LockModeType.OPTIMISTIC)
+    @Query("select s from Seat s where id = :seatId")
+    Optional<Seat> findByIdOptimisticLock(Long seatId);
 }

--- a/src/main/java/concert/infrastructure/user/UserJpaRepository.java
+++ b/src/main/java/concert/infrastructure/user/UserJpaRepository.java
@@ -14,4 +14,8 @@ public interface UserJpaRepository extends JpaRepository<User,Long> {
     @Lock(LockModeType.OPTIMISTIC)
     @Query("select u from User u where id = :id")
     Optional<User> findByIdWithOptimisticLock(Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where id = :id")
+    Optional<User> findByIdWithPessimisticLock(Long id);
 }

--- a/src/main/java/concert/infrastructure/user/UserJpaRepository.java
+++ b/src/main/java/concert/infrastructure/user/UserJpaRepository.java
@@ -1,10 +1,17 @@
 package concert.infrastructure.user;
 
 import concert.domain.user.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<User,Long> {
     Optional<User> findByEmail(String email);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("select u from User u where id = :id")
+    Optional<User> findByIdWithOptimisticLock(Long id);
 }

--- a/src/main/java/concert/infrastructure/user/UserRepositoryImpl.java
+++ b/src/main/java/concert/infrastructure/user/UserRepositoryImpl.java
@@ -40,4 +40,9 @@ public class UserRepositoryImpl implements UserRepository {
     public void deleteAllInBatch() {
         userJpaRepository.deleteAllInBatch();
     }
+
+    @Override
+    public Optional<User> findByIdWithOptimisticLock(Long id) {
+        return userJpaRepository.findByIdWithOptimisticLock(id);
+    }
 }

--- a/src/main/java/concert/infrastructure/user/UserRepositoryImpl.java
+++ b/src/main/java/concert/infrastructure/user/UserRepositoryImpl.java
@@ -45,4 +45,9 @@ public class UserRepositoryImpl implements UserRepository {
     public Optional<User> findByIdWithOptimisticLock(Long id) {
         return userJpaRepository.findByIdWithOptimisticLock(id);
     }
+
+    @Override
+    public Optional<User> findByIdWithPessimisticLock(Long id) {
+        return userJpaRepository.findByIdWithPessimisticLock(id);
+    }
 }

--- a/src/test/java/concert/application/ConcertFacadeTest.java
+++ b/src/test/java/concert/application/ConcertFacadeTest.java
@@ -66,7 +66,7 @@ class ConcertFacadeTest {
     @DisplayName("토큰이 Active상태일때 콘서트 스케줄을 조회할 수 있다..")
     void getConcertSchedule(){
 
-        userRepository.save(new User(null,"12@naver.com","1234","인호","01012345678",500));
+        userRepository.save(User.builder().phone("01012345678").build());
 
         Concert concert = concertRepository.save(new Concert(null, "임영웅", "임영웅"));
 
@@ -85,7 +85,7 @@ class ConcertFacadeTest {
     @DisplayName("현재 일시에 콘서트 스케줄을 조회할때 스케줄이 지나지 않은 콘서트 스케줄만 조회된다.")
     void getConcertSchedule_FAIL(){
         //given
-        userRepository.save(new User(null,"12@naver.com","1234","인호","01012345678",500));
+        userRepository.save(User.builder().phone("01012345678").build());
 
         Concert concert = concertRepository.save(new Concert(null, "임영웅 콘서트", "임영웅"));
         concertRepository.save(new ConcertSchedule(null,concert.getId(), LocalDateTime.now().minusDays(1)));

--- a/src/test/java/concert/application/WaitingTokenFacadeTest.java
+++ b/src/test/java/concert/application/WaitingTokenFacadeTest.java
@@ -40,7 +40,7 @@ class WaitingTokenFacadeTest {
     @DisplayName("토큰을 발급하면 대기열 토큰 db에 저장된다..")
     void issueToken(){
         //given
-        User user = userRepository.save(new User(1L, "12@naver.com", "1234", "인호", "01012345678", 5000));
+        User user = userRepository.save(User.builder().phone("01012345678").build());
         //when
         WaitingTokenIssueTokenDto issueTokenDto = waitingTokenFacade.issueToken(user.getId());
         WaitingToken waitingToken = waitingTokenRepository.findByUserId(user.getId()).get();

--- a/src/test/java/concert/domain/concert/ConcertServiceTest.java
+++ b/src/test/java/concert/domain/concert/ConcertServiceTest.java
@@ -41,10 +41,10 @@ class ConcertServiceTest {
         given(concertRepository.findByConcertIdAndConcertDateTime(concertId, now))
                 .willReturn(Optional.of(schedule));
 
-        Seat seat1 = new Seat(1L, 1L, 1, SeatStatus.AVAILABLE,2000);
-        Seat seat2 = new Seat(1L, 1L, 2, SeatStatus.AVAILABLE,2000);
-        Seat seat3 = new Seat(1L, 1L, 3, SeatStatus.RESERVED,2000);
-        Seat seat4 = new Seat(1L, 1L, 4, SeatStatus.RESERVED,2000);
+        Seat seat1 = Seat.builder().id(1L).concertScheduleId(1L).seatNumber(1).seatStatus(SeatStatus.AVAILABLE).seatPrice(2000).build();
+        Seat seat2 = Seat.builder().id(1L).concertScheduleId(1L).seatNumber(2).seatStatus(SeatStatus.AVAILABLE).seatPrice(2000).build();
+        Seat seat3 = Seat.builder().id(1L).concertScheduleId(1L).seatNumber(3).seatStatus(SeatStatus.RESERVED).seatPrice(2000).build();
+        Seat seat4 = Seat.builder().id(1L).concertScheduleId(1L).seatNumber(4).seatStatus(SeatStatus.RESERVED).seatPrice(2000).build();
         given(concertRepository.findByConcertScheduleIdAndSeatStatus(schedule.getConcertId(), SeatStatus.AVAILABLE))
                 .willReturn(List.of(seat1,seat2,seat3,seat4));
         //when

--- a/src/test/java/concert/domain/reservation/ReservationConcurrencyPessimisticTest.java
+++ b/src/test/java/concert/domain/reservation/ReservationConcurrencyPessimisticTest.java
@@ -1,12 +1,9 @@
 package concert.domain.reservation;
 
 import concert.application.ReservationFacade;
-import concert.application.dto.ReservationDto;
-import concert.common.exception.BusinessException;
 import concert.domain.concert.*;
 import concert.domain.user.User;
 import concert.domain.user.UserRepository;
-import jakarta.persistence.OptimisticLockException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
@@ -22,12 +18,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 @ActiveProfiles("test")
 @SpringBootTest
-class ReservationConcurrencyOptimisticTest {
+class ReservationConcurrencyPessimisticTest {
 
     @Autowired
     private ReservationFacade reservationFacade;
@@ -59,12 +52,11 @@ class ReservationConcurrencyOptimisticTest {
                 .seatNumber(1)
                 .seatStatus(SeatStatus.AVAILABLE)
                 .seatPrice(100)
-//                .version(0L)
                 .build());
     }
 
     /**
-     * 낙관적 락을 통한 동시성 제어
+     * 비관적 락을 통한 동시성 제어
      */
     @Test
     @DisplayName("userId가 다른 10명이 같은 좌석을 예약할 때 1명만 좌석을 예약할 수 있다.")

--- a/src/test/java/concert/domain/user/UserPointConcurrencyOptimisticLock.java
+++ b/src/test/java/concert/domain/user/UserPointConcurrencyOptimisticLock.java
@@ -1,0 +1,70 @@
+package concert.domain.user;
+
+import concert.application.UserFacade;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class UserPointConcurrencyOptimisticLock {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserFacade userFacade;
+
+    private static final int numberOfThreads = 1000;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.save(User.builder().amount(0).version(0L).username("정인호").build());
+    }
+
+    @Test
+    @DisplayName("한 유저가 0원을 가지고 있고 포인트를 1000원씩 1000번 충전할때 1000000원이 나와야 한다.")
+    void UserPointConcurrencyOptimisticLock() throws InterruptedException {
+        long startTime = System.currentTimeMillis();
+        System.out.println("Execution time with Composite Key Test Start " + startTime + "ms");
+        AtomicInteger failedReservations = new AtomicInteger(0);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        Long userId = 1L;
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    userFacade.chargeAmount(userId,1000);
+                }catch (OptimisticLockingFailureException e){
+                    failedReservations.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        int failCount = failedReservations.get();
+        long endTime = System.currentTimeMillis();
+        long executionTime = endTime - startTime;
+        System.out.println("Execution time with Composite Key: " + executionTime + "ms");
+        User user = userRepository.findById(userId).get();
+        Assertions.assertThat(user.getAmount()).isEqualTo(1000000 - (failCount * 1000));
+
+    }
+}

--- a/src/test/java/concert/domain/user/UserPointConcurrencyPessimisticLock.java
+++ b/src/test/java/concert/domain/user/UserPointConcurrencyPessimisticLock.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @ActiveProfiles("test")
 @SpringBootTest
-public class UserPointConcurrencyOptimisticLock {
+public class UserPointConcurrencyPessimisticLock {
 
     @Autowired
     private UserRepository userRepository;
@@ -34,9 +34,9 @@ public class UserPointConcurrencyOptimisticLock {
 
     @Test
     @DisplayName("한 유저가 0원을 가지고 있고 포인트를 1000원씩 1000번 충전할때 1000000원이 나와야 한다.")
-    void UserPointConcurrencyOptimisticLock() throws InterruptedException {
+    void UserPointConcurrencyPessimisticLock() throws InterruptedException {
         long startTime = System.currentTimeMillis();
-        System.out.println("Execution time with Composite Key Test Start " + startTime + "ms");
+        System.out.println("Execution time with PessimisticLock Test Start " + startTime + "ms");
         AtomicInteger failedReservations = new AtomicInteger(0);
 
         ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
@@ -48,9 +48,7 @@ public class UserPointConcurrencyOptimisticLock {
             executorService.submit(() -> {
                 try {
                     userFacade.chargeAmount(userId,1000);
-                }catch (OptimisticLockingFailureException e){
-                    failedReservations.incrementAndGet();
-                } finally {
+                }finally {
                     latch.countDown();
                 }
             });
@@ -59,12 +57,11 @@ public class UserPointConcurrencyOptimisticLock {
         latch.await();
         executorService.shutdown();
 
-        int failCount = failedReservations.get();
         long endTime = System.currentTimeMillis();
         long executionTime = endTime - startTime;
-        System.out.println("Execution time with Optimistic Lock: " + executionTime + "ms");
+        System.out.println("Execution time with Pessimistic Lock: " + executionTime + "ms");
         User user = userRepository.findById(userId).get();
-        Assertions.assertThat(user.getAmount()).isEqualTo(1000000 - (failCount * 1000));
+        Assertions.assertThat(user.getAmount()).isEqualTo(1000000);
 
     }
 }

--- a/src/test/java/concert/domain/user/UserServiceTest.java
+++ b/src/test/java/concert/domain/user/UserServiceTest.java
@@ -35,7 +35,7 @@ class UserServiceTest {
         //given
         int chargeAmount = 300;
         int userAmount = 5500;
-        User user = new User(null, "1@naver.com", "1234", "이노", "01012345678", userAmount);
+        User user = userRepository.save(User.builder().phone("01012345678").amount(userAmount).build());
         userRepository.save(user);
         //when
         AmountChargeDto amountHistory = userService.chargeAmount(user.getId(), chargeAmount);

--- a/src/test/java/concert/domain/user/UserTest.java
+++ b/src/test/java/concert/domain/user/UserTest.java
@@ -12,7 +12,7 @@ class UserTest {
     void getAmount(){
         //given
         int userAmount = 5000;
-        User user = new User(1L, "1234@naver.com", "1234", "이노", "01012345678", userAmount);
+        User user = User.builder().phone("01012345678").amount(userAmount).build();
         //when
         int amount = user.getAmount();
         //then
@@ -25,7 +25,7 @@ class UserTest {
         //given
         long chargeAmount = 2000;
         int userAmount = 5000;
-        User user = new User(1L, "1234@naver.com", "1234", "이노", "01012345678", userAmount);
+        User user = User.builder().phone("01012345678").amount(userAmount).build();
         //when
         int amount = user.chargeAmount(chargeAmount);
         //then

--- a/src/test/java/concert/infrastructure/concert/SeatJpaRepositoryTest.java
+++ b/src/test/java/concert/infrastructure/concert/SeatJpaRepositoryTest.java
@@ -27,11 +27,11 @@ class SeatJpaRepositoryTest {
     @DisplayName("이용가능한 좌석들을 보여준다.")
     void availableSeatsCount(){
         //given
-        seatJpaRepository.save(new Seat(1L,1L,1, SeatStatus.AVAILABLE,2000));
-        seatJpaRepository.save(new Seat(2L,1L,2, SeatStatus.AVAILABLE,2000));
-        seatJpaRepository.save(new Seat(3L,1L,3, SeatStatus.RESERVED,2000));
-        seatJpaRepository.save(new Seat(4L,1L,4, SeatStatus.RESERVED,2000));
-        seatJpaRepository.save(new Seat(5L,1L,5, SeatStatus.RESERVED,2000));
+        seatJpaRepository.save(Seat.builder().id(1L).concertScheduleId(1L).seatNumber(1).seatStatus(SeatStatus.AVAILABLE).seatPrice(2000).build());
+        seatJpaRepository.save(Seat.builder().id(2L).concertScheduleId(1L).seatNumber(2).seatStatus(SeatStatus.AVAILABLE).seatPrice(2000).build());
+        seatJpaRepository.save(Seat.builder().id(3L).concertScheduleId(1L).seatNumber(3).seatStatus(SeatStatus.RESERVED).seatPrice(2000).build());
+        seatJpaRepository.save(Seat.builder().id(4L).concertScheduleId(1L).seatNumber(4).seatStatus(SeatStatus.RESERVED).seatPrice(2000).build());
+        seatJpaRepository.save(Seat.builder().id(5L).concertScheduleId(1L).seatNumber(5).seatStatus(SeatStatus.RESERVED).seatPrice(2000).build());
         //when
         //then
         List<Seat> seatList = concertRepository.findByConcertScheduleIdAndSeatStatus(1L, SeatStatus.AVAILABLE);


### PR DESCRIPTION
## 동시성 문제에 대한 기술적 고민
### 콘서트 좌석 예약 동시성 해결(낙관적 락)
- 충돌이 안난다는 가정하에, 별도의 락을 잡지 않으므로 Pessimistic Lock 보다는 성능적 이점을 가진다고 생각했습니다.
- Optimistic Lock 의 단점인 업데이트가 실패했을 때 재시도 로직을 직접 작성해야 되는 것인데 콘서트 좌석 예약은 재시도로직을 작성할 필요없이 예외 메세지를 보내고 다른 예약들을 실패처리 하면 된다고 생각했습니다.
- 아래와 같이 속도도 우세한 걸 확인했습니다.
  - 쓰레드 1000개 동시성 테스트 결과 - 낙관적 락 (2579ms) 
  - 쓰레드 1000개 동시성 테스트 결과 - 비관적 락 (5762ms)
### 포인트 충전 동시성 해결(비관적 락)
- 돈과 관련이 있기 때문에 데이터 정합성을 고려하여 선택하였습니다.
- 낙관적 락으로 구현시 재시도 로직으로 인하여 어떻게 할지 모르겠어서 동시에 요청이 오면 예외 메시지를 보내고 충전을 시키지 않도록 구현했습니다.
- 데이터 정합성을 보장하기 위해서 선택하였지만  별도의 락을 잡기때문에 동시성이 떨어져 성능저하가 발생하고 서로 자원이 필요한 경우 데드락이 발생할 가능성이 있습니다.
-  아래와 같이 속도가 비슷한걸 확인하였습니다.
    - 쓰레드 1000개 동시성 테스트 결과 - 낙관적 락 (4613ms) 
    - 쓰레드 1000개 동시성 테스트 결과 - 비관적 락 (4449ms)

### 궁금한 점
- 락을 사용하지 않고 동시성 제어를 하는것이 좋다고 생각하였는데 복합키로 좌석 예약에 대한 동시성 처리는 어떻게 생각하시는지 궁금합니다.!
