### PR TITLE
[#28]refactor: 대기열 토큰 발급 api 계속 요청 시 사용자가 ACTIVE나 WAIT 상태의 토큰을 여러 개 가질 수 있는 상황이 발생

### DIFF
--- a/counter.js
+++ b/counter.js
@@ -1,0 +1,8 @@
+let counter = 1;  // 시작값
+
+module.exports = {
+  generateUserId: function(context, events, done) {
+    context.vars.userId = counter++;  // 1씩 증가
+    return done();
+  }
+};

--- a/src/main/java/concert/domain/token/WaitingTokenRepository.java
+++ b/src/main/java/concert/domain/token/WaitingTokenRepository.java
@@ -16,4 +16,8 @@ public interface WaitingTokenRepository {
     List<WaitingToken>  findByExpiredAtBeforeAndTokenStatus(LocalDateTime now,TokenStatus status);
     List<WaitingToken> saveAll(List<WaitingToken> waitingTokenList);
     List<WaitingToken> findByTokenStatusOrderByCreatedAt(TokenStatus tokenStatus, Pageable pageable);
+    Optional<WaitingToken> findFirstByUserIdAndTokenStatusInOrderByCreatedAtDesc(Long userId, List<TokenStatus> statuses);
+    Optional<WaitingToken> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
+
+    long countByTokenStatusAndCreatedAtLessThanEqual(TokenStatus tokenStatus, LocalDateTime createdAt);
 }

--- a/src/main/java/concert/domain/token/entity/WaitingToken.java
+++ b/src/main/java/concert/domain/token/entity/WaitingToken.java
@@ -29,19 +29,11 @@ public class WaitingToken {
     private LocalDateTime createdAt;
     private LocalDateTime expiredAt;
 
-    public static WaitingToken issue(Long userId, int activeTokenCount,int fixActiveCount ,int expirationMinutes) {
-        log.info("WaitingToken issue: userId={}",userId);
+    public static WaitingToken issue(Long userId, int activeTokenCount,
+                                     int fixActiveCount, int expirationMinutes) {
+        log.info("WaitingToken issue: userId={}", userId);
         LocalDateTime now = LocalDateTime.now();
-        TokenStatus tokenStatus = validTokenStatus(activeTokenCount, fixActiveCount);
-
-        if (tokenStatus.equals(TokenStatus.ACTIVE)){
-            return  WaitingToken.builder()
-                    .userId(userId)
-                    .tokenStatus(tokenStatus)
-                    .createdAt(now)
-                    .expiredAt(now.plusMinutes(expirationMinutes))
-                    .build();
-        }
+        TokenStatus tokenStatus = determineTokenStatus(activeTokenCount, fixActiveCount);
 
         return WaitingToken.builder()
                 .userId(userId)
@@ -51,7 +43,7 @@ public class WaitingToken {
                 .build();
     }
 
-    private static TokenStatus validTokenStatus(int activeTokenCount,int fixActiveCount) {
+    private static TokenStatus determineTokenStatus(int activeTokenCount, int fixActiveCount) {
         return activeTokenCount < fixActiveCount ? TokenStatus.ACTIVE : TokenStatus.WAIT;
     }
 
@@ -63,5 +55,6 @@ public class WaitingToken {
 
     public void expire() {
         this.tokenStatus = TokenStatus.EXPIRED;
+        this.expiredAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/concert/domain/token/jwt/WaitingTokenValidator.java
+++ b/src/main/java/concert/domain/token/jwt/WaitingTokenValidator.java
@@ -51,7 +51,7 @@ public class WaitingTokenValidator {
     }
 
     private void validateTokenStatus(Long userId) {
-        WaitingToken waitingToken = waitingTokenRepository.findByUserId(userId)
+        WaitingToken waitingToken = waitingTokenRepository.findFirstByUserIdOrderByCreatedAtDesc(userId)
                 .orElseThrow(() -> new BusinessException("토큰이 존재하지 않습니다."));
 
         if (waitingToken.getTokenStatus().equals(TokenStatus.EXPIRED)) {

--- a/src/main/java/concert/infrastructure/token/WaitingTokenRepositoryImpl.java
+++ b/src/main/java/concert/infrastructure/token/WaitingTokenRepositoryImpl.java
@@ -39,7 +39,7 @@ public class WaitingTokenRepositoryImpl implements WaitingTokenRepository {
 
     @Override
     public List<WaitingToken> findByExpiredAtBeforeAndTokenStatus(LocalDateTime now, TokenStatus status) {
-        return watingTokenJpaRepository.findByExpiredAtBeforeAndTokenStatus(now,status);
+        return watingTokenJpaRepository.findByExpiredAtBeforeAndTokenStatus(now, status);
     }
 
     @Override
@@ -49,7 +49,21 @@ public class WaitingTokenRepositoryImpl implements WaitingTokenRepository {
 
     @Override
     public List<WaitingToken> findByTokenStatusOrderByCreatedAt(TokenStatus status, Pageable pageable) {
-        return watingTokenJpaRepository.findByTokenStatusOrderByCreatedAt(status,pageable);
+        return watingTokenJpaRepository.findByTokenStatusOrderByCreatedAt(status, pageable);
     }
 
+    @Override
+    public Optional<WaitingToken> findFirstByUserIdAndTokenStatusInOrderByCreatedAtDesc(Long userId, List<TokenStatus> statuses) {
+        return watingTokenJpaRepository.findFirstByUserIdAndTokenStatusInOrderByCreatedAtDesc(userId, statuses);
+    }
+
+    @Override
+    public Optional<WaitingToken> findFirstByUserIdOrderByCreatedAtDesc(Long userId) {
+        return watingTokenJpaRepository.findFirstByUserIdOrderByCreatedAtDesc(userId);
+    }
+
+    @Override
+    public long countByTokenStatusAndCreatedAtLessThanEqual(TokenStatus tokenStatus, LocalDateTime createdAt) {
+        return watingTokenJpaRepository.countByTokenStatusAndCreatedAtLessThanEqual(tokenStatus,createdAt);
+    }
 }

--- a/src/main/java/concert/infrastructure/token/WatingTokenJpaRepository.java
+++ b/src/main/java/concert/infrastructure/token/WatingTokenJpaRepository.java
@@ -22,4 +22,9 @@ public interface WatingTokenJpaRepository extends JpaRepository<WaitingToken,Lon
 
     @Query("SELECT w FROM WaitingToken w WHERE w.tokenStatus = :tokenStatus ORDER BY w.createdAt")
     List<WaitingToken> findByTokenStatusOrderByCreatedAt(TokenStatus tokenStatus, Pageable pageable);
+
+    Optional<WaitingToken> findFirstByUserIdAndTokenStatusInOrderByCreatedAtDesc(Long userId, List<TokenStatus> statuses);
+    Optional<WaitingToken> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
+    long countByTokenStatusAndCreatedAtLessThanEqual(TokenStatus tokenStatus, LocalDateTime createdAt);
+
 }

--- a/test-config.yml
+++ b/test-config.yml
@@ -1,0 +1,47 @@
+# MySQL 성능 테스트
+# 총 15600명 총 5분동안 요청
+config:
+  target: "http://localhost:8080"
+  phases:
+    # Phase 1: 초당 10명
+    - duration: 60
+      arrivalRate: 10
+
+    # Phase 2: 초당 30명
+    - duration: 60
+      arrivalRate: 30
+
+    # Phase 3: 초당 50명
+    - duration: 60
+      arrivalRate: 50
+
+    # Phase 4: 초당 70명
+    - duration: 60
+      arrivalRate: 70
+
+    # Phase 5: 초당 100명
+    - duration: 60
+      arrivalRate: 100
+  processor: "./counter.js"
+
+scenarios:
+  - name: "대기열 성능 테스트"
+    flow:
+      - function: "generateUserId"
+      # 1. 토큰 발급 테스트
+      - post:
+          url: "/concerts/tokens/{{ $randomNumber(1,1000) }}"
+          capture:
+            - json: "$.jwtToken"
+              as: "authToken"
+          expect:
+            - statusCode: 200
+
+      # 2. 대기열 상태 확인 (토큰 발급 성공한 경우만)
+      - think: 2  # 2초 대기
+      - get:
+          url: "/concerts/tokens"
+          headers:
+            WaitingToken: "{{ authToken }}"
+          expect:
+            - statusCode: 200


### PR DESCRIPTION
-> 이를 해결하기 위해 가장 최근 토큰을 기준으로 처리하도록 수정